### PR TITLE
refactor(Calcified): use `Int`s instead of `Byte`s for port numbers i…

### DIFF
--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/CalcifiedDeviceMap.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/CalcifiedDeviceMap.kt
@@ -2,5 +2,5 @@ package dev.frozenmilk.dairy.calcified
 
 import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 
-abstract class CalcifiedDeviceMap<T> internal constructor(protected val module: CalcifiedModule, private val map: MutableMap<Byte, T> = mutableMapOf()) : MutableMap<Byte, T> by map
+abstract class CalcifiedDeviceMap<T> internal constructor(protected val module: CalcifiedModule, private val map: MutableMap<Int, T> = mutableMapOf()) : MutableMap<Int, T> by map
 

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/CalcifiedModule.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/CalcifiedModule.kt
@@ -34,7 +34,7 @@ class CalcifiedModule(val lynxModule: LynxModule) {
 	val i2cDevices = I2CDevices(this)
 	val digitalChannels = DigitalChannels(this)
 	val analogInputs = AnalogInputs(this)
-	var deviceMap: MutableMap<Class<*>, MutableMap<Byte, out Any>> = mutableMapOf(
+	var deviceMap: MutableMap<Class<*>, MutableMap<Int, out Any>> = mutableMapOf(
 			CalcifiedMotor::class.java to motors,
 			CalcifiedEncoder::class.java to encoders,
 			CalcifiedServo::class.java to PWMDevices,
@@ -45,7 +45,7 @@ class CalcifiedModule(val lynxModule: LynxModule) {
 	)
 		private set
 
-	fun <T> unsafeGet(type: Class<out T>, port: Byte): T {
+	fun <T> unsafeGet(type: Class<out T>, port: Int): T {
 		val resultMap = deviceMap[type]
 				?: throw IllegalArgumentException("no mappings of type ${type.simpleName} in this module's device mapping")
 		val result = resultMap[port]
@@ -62,65 +62,65 @@ class CalcifiedModule(val lynxModule: LynxModule) {
 	}
 
 	fun refreshBulkCache() {
-		bulkData = LynxGetBulkInputDataCommand(lynxModule).sendReceive();
+		bulkData = LynxGetBulkInputDataCommand(lynxModule).sendReceive()
 	}
 
 	//
 	// Remaps to the device maps
 	//
 
-	fun getMotor(port: Byte): CalcifiedMotor {
+	fun getMotor(port: Int): CalcifiedMotor {
 		return motors.getMotor(port)
 	}
 
-	fun getTicksEncoder(port: Byte): TicksEncoder {
+	fun getTicksEncoder(port: Int): TicksEncoder {
 		return encoders.getTicksEncoder(port)
 	}
 
-	fun getAttachedEncoder(port: Byte) : Encoder<*>? {
+	fun getAttachedEncoder(port: Int) : Encoder<*>? {
 		return encoders.getEncoder(port)
 	}
 
-	fun getDistanceEncoder(port: Byte, unit: DistanceUnit, ticksPerUnit: Double): DistanceEncoder {
-		return encoders.getDistanceEncoder(port, unit, ticksPerUnit);
+	fun getDistanceEncoder(port: Int, unit: DistanceUnit, ticksPerUnit: Double): DistanceEncoder {
+		return encoders.getDistanceEncoder(port, unit, ticksPerUnit)
 	}
 
-	fun getAngleEncoder(port: Byte, wrapping: Wrapping, ticksPerRevolution: Double): AngleEncoder {
+	fun getAngleEncoder(port: Int, wrapping: Wrapping, ticksPerRevolution: Double): AngleEncoder {
 		return encoders.getAngleEncoder(port, wrapping, ticksPerRevolution)
 	}
 
-	fun getServo(port: Byte): CalcifiedServo {
+	fun getServo(port: Int): CalcifiedServo {
 		return PWMDevices.getServo(port)
 	}
 
-	fun getContinuousServo(port: Byte): CalcifiedContinuousServo {
+	fun getContinuousServo(port: Int): CalcifiedContinuousServo {
 		return PWMDevices.getContinuousServo(port)
 	}
 
 	@JvmOverloads
-	fun getIMU_BHI260(port: Byte = 0, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()): CalcifiedIMU {
+	fun getIMU_BHI260(port: Int = 0, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()): CalcifiedIMU {
 		return i2cDevices.getIMU_BHI260(port, angleBasedRobotOrientation)
 	}
 
 	@JvmOverloads
-	fun getIMU_BNO055(port: Byte = 0, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()): CalcifiedIMU {
+	fun getIMU_BNO055(port: Int = 0, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()): CalcifiedIMU {
 		return i2cDevices.getIMU_BNO055(port, angleBasedRobotOrientation)
 	}
 
 	@JvmOverloads
-	fun getIMU(port: Byte = 0, lynxModuleImuType: LynxModuleImuType = lynxModule.imuType, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()): CalcifiedIMU {
+	fun getIMU(port: Int = 0, lynxModuleImuType: LynxModuleImuType = lynxModule.imuType, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()): CalcifiedIMU {
 		return i2cDevices.getIMU(port, lynxModuleImuType, angleBasedRobotOrientation)
 	}
 
-	fun getDigitalInput(port: Byte): CalcifiedDigitalInput {
+	fun getDigitalInput(port: Int): CalcifiedDigitalInput {
 		return digitalChannels.getInput(port)
 	}
 
-	fun getDigitalOutput(port: Byte): CalcifiedDigitalOutput {
+	fun getDigitalOutput(port: Int): CalcifiedDigitalOutput {
 		return digitalChannels.getOutput(port)
 	}
 
-	fun getAnalogInput(port: Byte): CalcifiedAnalogInput {
+	fun getAnalogInput(port: Int): CalcifiedAnalogInput {
 		return analogInputs.getInput(port)
 	}
 }

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/encoder/CalcifiedEncoder.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/encoder/CalcifiedEncoder.kt
@@ -4,7 +4,7 @@ import com.qualcomm.hardware.lynx.commands.core.LynxResetMotorEncoderCommand
 import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 import dev.frozenmilk.dairy.calcified.hardware.motor.Direction
 
-abstract class CalcifiedEncoder<T: Comparable<T>> internal constructor(val module: CalcifiedModule, val port: Byte, ) : AbstractEncoder<T>() {
+abstract class CalcifiedEncoder<T: Comparable<T>> internal constructor(val module: CalcifiedModule, val port: Int) : AbstractEncoder<T>() {
 	override var direction = Direction.FORWARD
 	protected abstract val zero: T
 	override fun reset() {

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/encoder/Encoders.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/encoder/Encoders.kt
@@ -12,7 +12,7 @@ class Encoders internal constructor(module: CalcifiedModule) : CalcifiedDeviceMa
 	/**
 	 * if the port is empty, makes a new [TicksEncoder], else, overrides the encoder on the port
 	 */
-	fun getTicksEncoder(port: Byte): TicksEncoder {
+	fun getTicksEncoder(port: Int): TicksEncoder {
 		// this is pretty much the same as the motors, as the encoders match the motors
 		// checks to confirm that the encoder port is validly in range
 		if (port !in LynxConstants.INITIAL_MOTOR_PORT until LynxConstants.INITIAL_MOTOR_PORT + LynxConstants.NUMBER_OF_MOTORS) throw IllegalArgumentException("$port is not in the acceptable port range [${LynxConstants.INITIAL_MOTOR_PORT}, ${LynxConstants.INITIAL_MOTOR_PORT + LynxConstants.NUMBER_OF_MOTORS - 1}]")
@@ -27,20 +27,20 @@ class Encoders internal constructor(module: CalcifiedModule) : CalcifiedDeviceMa
 	 *
 	 * @return Overrides the encoder on the port with a [Encoder] of the supplied type
 	 */
-	inline fun <reified T : Encoder<*>> getEncoder(lazySupplier: (TicksEncoder) -> T, port: Byte): T {
+	inline fun <reified T : Encoder<*>> getEncoder(lazySupplier: (TicksEncoder) -> T, port: Int): T {
 		val ticksEncoder = getTicksEncoder(port)
 		this[port] = lazySupplier(ticksEncoder)
 		return this[port] as? T ?: throw IllegalStateException("something went wrong while creating a new encoder, this shouldn't be reachable")
 	}
 
-	inline fun <reified T : Encoder<*>> getEncoder(port: Byte): T? {
+	inline fun <reified T : Encoder<*>> getEncoder(port: Int): T? {
 		return this[port] as? T
 	}
 
 	/**
 	 * overrides the encoder on the port with an [AngleEncoder], with the [ticksPerRevolution] and [wrapping] specified
 	 */
-	fun getAngleEncoder(port: Byte, wrapping: Wrapping, ticksPerRevolution: Double): AngleEncoder {
+	fun getAngleEncoder(port: Int, wrapping: Wrapping, ticksPerRevolution: Double): AngleEncoder {
 		return getEncoder({
 			AngleEncoder(it, wrapping, ticksPerRevolution)
 		}, port)
@@ -49,7 +49,7 @@ class Encoders internal constructor(module: CalcifiedModule) : CalcifiedDeviceMa
 	/**
 	 * overrides the encoder on the port with a [DistanceEncoder], with the [ticksPerUnit] specified
 	 */
-	fun getDistanceEncoder(port: Byte, unit: DistanceUnit, ticksPerUnit: Double): DistanceEncoder {
+	fun getDistanceEncoder(port: Int, unit: DistanceUnit, ticksPerUnit: Double): DistanceEncoder {
 		return getEncoder({
 			DistanceEncoder(it, unit, ticksPerUnit)
 		}, port)

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/encoder/TicksEncoder.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/encoder/TicksEncoder.kt
@@ -3,7 +3,7 @@ package dev.frozenmilk.dairy.calcified.hardware.encoder
 import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 import dev.frozenmilk.dairy.core.util.supplier.numeric.EnhancedDoubleSupplier
 
-class TicksEncoder internal constructor(module: CalcifiedModule, port: Byte) : CalcifiedEncoder<Double>(module, port) {
+class TicksEncoder internal constructor(module: CalcifiedModule, port: Int) : CalcifiedEncoder<Double>(module, port) {
 	override val enhancedSupplier = EnhancedDoubleSupplier({ module.bulkData.getEncoder(port.toInt()).toDouble() * direction.multiplier })
 	override val zero = 0.0
 }

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/motor/Motors.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/motor/Motors.kt
@@ -5,7 +5,7 @@ import dev.frozenmilk.dairy.calcified.CalcifiedDeviceMap
 import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 
 class Motors internal constructor(module: CalcifiedModule) : CalcifiedDeviceMap<CalcifiedMotor>(module) {
-	fun getMotor(port: Byte): CalcifiedMotor {
+	fun getMotor(port: Int): CalcifiedMotor {
 		// checks to confirm that the motor port is validly in range
 		if (port !in LynxConstants.INITIAL_MOTOR_PORT until LynxConstants.INITIAL_MOTOR_PORT + LynxConstants.NUMBER_OF_MOTORS) throw IllegalArgumentException("$port is not in the acceptable port range [${LynxConstants.INITIAL_MOTOR_PORT}, ${LynxConstants.INITIAL_MOTOR_PORT + LynxConstants.NUMBER_OF_MOTORS - 1}]")
 		this.putIfAbsent(port, CalcifiedMotor(module, port))

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/pwm/CalcifiedContinuousServo.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/pwm/CalcifiedContinuousServo.kt
@@ -10,12 +10,12 @@ import dev.frozenmilk.dairy.calcified.hardware.motor.Direction
 import dev.frozenmilk.dairy.calcified.hardware.motor.SimpleMotor
 import kotlin.math.abs
 
-class CalcifiedContinuousServo internal constructor(val module: CalcifiedModule, val port: Byte) : SimpleMotor, PWMDevice {
+class CalcifiedContinuousServo internal constructor(val module: CalcifiedModule, val port: Int) : SimpleMotor, PWMDevice {
 	override var direction = Direction.FORWARD
 	override var pwmRange: PwmControl.PwmRange = PwmControl.PwmRange.defaultRange
 		set(value) {
 			if (value.usFrame != field.usFrame) {
-				LynxSetServoConfigurationCommand(module.lynxModule, port.toInt(), value.usFrame.toInt()).send()
+				LynxSetServoConfigurationCommand(module.lynxModule, port, value.usFrame.toInt()).send()
 			}
 			field = value
 		}
@@ -27,7 +27,7 @@ class CalcifiedContinuousServo internal constructor(val module: CalcifiedModule,
 			firstEnable = true
 			if (field != value) {
 				// sends the command to change the enable state
-				LynxSetServoEnableCommand(module.lynxModule, port.toInt(), value).send()
+				LynxSetServoEnableCommand(module.lynxModule, port, value).send()
 				field = value
 			}
 		}
@@ -44,13 +44,13 @@ class CalcifiedContinuousServo internal constructor(val module: CalcifiedModule,
 						.toInt()
 						.coerceIn(LynxSetServoPulseWidthCommand.apiPulseWidthFirst, LynxSetServoPulseWidthCommand.apiPulseWidthLast)
 
-				LynxSetServoPulseWidthCommand(module.lynxModule, port.toInt(), pwm).send()
+				LynxSetServoPulseWidthCommand(module.lynxModule, port, pwm).send()
 				field = correctedValue
 			}
 			if (!firstEnable) enabled = true
 		}
 
 	init {
-		LynxSetServoConfigurationCommand(module.lynxModule, port.toInt(), pwmRange.usFrame.toInt()).send()
+		LynxSetServoConfigurationCommand(module.lynxModule, port, pwmRange.usFrame.toInt()).send()
 	}
 }

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/pwm/CalcifiedServo.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/pwm/CalcifiedServo.kt
@@ -9,13 +9,13 @@ import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 import dev.frozenmilk.dairy.calcified.hardware.motor.Direction
 import kotlin.math.abs
 
-class CalcifiedServo internal constructor(val module: CalcifiedModule, val port: Byte) : PWMDevice {
-	var direction = Direction.FORWARD;
+class CalcifiedServo internal constructor(val module: CalcifiedModule, val port: Int) : PWMDevice {
+	var direction = Direction.FORWARD
 
 	override var pwmRange: PwmRange = PwmRange.defaultRange
 		set(value) {
 			if (value.usFrame != field.usFrame) {
-				LynxSetServoConfigurationCommand(module.lynxModule, port.toInt(), value.usFrame.toInt()).send()
+				LynxSetServoConfigurationCommand(module.lynxModule, port, value.usFrame.toInt()).send()
 			}
 			field = value
 		}
@@ -26,8 +26,8 @@ class CalcifiedServo internal constructor(val module: CalcifiedModule, val port:
 		set(value) {
 			firstEnable = true
 			if (field != value) {
-				LynxSetServoEnableCommand(module.lynxModule, port.toInt(), value).send()
-				field = value;
+				LynxSetServoEnableCommand(module.lynxModule, port, value).send()
+				field = value
 			}
 		}
 
@@ -43,7 +43,7 @@ class CalcifiedServo internal constructor(val module: CalcifiedModule, val port:
 						.toInt()
 						.coerceIn(LynxSetServoPulseWidthCommand.apiPulseWidthFirst, LynxSetServoPulseWidthCommand.apiPulseWidthLast)
 
-				LynxSetServoPulseWidthCommand(module.lynxModule, port.toInt(), pwm).send()
+				LynxSetServoPulseWidthCommand(module.lynxModule, port, pwm).send()
 				field = correctedValue
 			}
 			if (!firstEnable) enabled = true
@@ -60,6 +60,6 @@ class CalcifiedServo internal constructor(val module: CalcifiedModule, val port:
 	}
 
 	init {
-		LynxSetServoConfigurationCommand(module.lynxModule, port.toInt(), pwmRange.usFrame.toInt()).send()
+		LynxSetServoConfigurationCommand(module.lynxModule, port, pwmRange.usFrame.toInt()).send()
 	}
 }

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/pwm/PWMDevices.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/pwm/PWMDevices.kt
@@ -5,7 +5,7 @@ import dev.frozenmilk.dairy.calcified.CalcifiedDeviceMap
 import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 
 class PWMDevices internal constructor(module: CalcifiedModule) : CalcifiedDeviceMap<PWMDevice>(module) {
-	fun getServo(port: Byte): CalcifiedServo {
+	fun getServo(port: Int): CalcifiedServo {
 		if (port !in LynxConstants.INITIAL_SERVO_PORT until LynxConstants.INITIAL_SERVO_PORT + LynxConstants.NUMBER_OF_SERVO_CHANNELS) throw IllegalArgumentException("$port is not in the acceptable port range [${LynxConstants.INITIAL_SERVO_PORT}, ${LynxConstants.INITIAL_SERVO_PORT + LynxConstants.NUMBER_OF_SERVO_CHANNELS - 1}]")
 		if (!this.containsKey(port) || this[port] !is CalcifiedServo) {
 			this[port] = CalcifiedServo(module, port)
@@ -13,7 +13,7 @@ class PWMDevices internal constructor(module: CalcifiedModule) : CalcifiedDevice
 		return (this[port] as CalcifiedServo)
 	}
 
-	fun getContinuousServo(port: Byte): CalcifiedContinuousServo {
+	fun getContinuousServo(port: Int): CalcifiedContinuousServo {
 		if (port !in LynxConstants.INITIAL_SERVO_PORT until LynxConstants.INITIAL_SERVO_PORT + LynxConstants.NUMBER_OF_SERVO_CHANNELS) throw IllegalArgumentException("$port is not in the acceptable port range [${LynxConstants.INITIAL_SERVO_PORT}, ${LynxConstants.INITIAL_SERVO_PORT + LynxConstants.NUMBER_OF_SERVO_CHANNELS - 1}]")
 		if (!this.containsKey(port) || this[port] !is CalcifiedContinuousServo) {
 			this[port] = CalcifiedContinuousServo(module, port)

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/AnalogInputs.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/AnalogInputs.kt
@@ -5,7 +5,7 @@ import dev.frozenmilk.dairy.calcified.CalcifiedDeviceMap
 import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 
 class AnalogInputs internal constructor(module: CalcifiedModule) : CalcifiedDeviceMap<CalcifiedAnalogInput>(module) {
-	fun getInput(port: Byte): CalcifiedAnalogInput {
+	fun getInput(port: Int): CalcifiedAnalogInput {
 		if (port !in 0 until LynxConstants.NUMBER_OF_ANALOG_INPUTS) throw IllegalArgumentException("$port is not in the acceptable port range [0, ${LynxConstants.NUMBER_OF_ANALOG_INPUTS - 1}]")
 		this.putIfAbsent(port, CalcifiedAnalogInput(module, port))
 		return this[port]!!

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/CalcifiedAnalogInput.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/CalcifiedAnalogInput.kt
@@ -5,4 +5,4 @@ import dev.frozenmilk.dairy.core.util.supplier.logical.Conditional
 import dev.frozenmilk.dairy.core.util.supplier.numeric.EnhancedComparableNumericSupplier
 import dev.frozenmilk.dairy.core.util.supplier.numeric.EnhancedDoubleSupplier
 
-class CalcifiedAnalogInput(val module: CalcifiedModule, val port: Byte) : EnhancedComparableNumericSupplier<Double, Conditional<Double>> by EnhancedDoubleSupplier({ module.bulkData.getAnalogInput(port.toInt()).toDouble() })
+class CalcifiedAnalogInput(val module: CalcifiedModule, val port: Int) : EnhancedComparableNumericSupplier<Double, Conditional<Double>> by EnhancedDoubleSupplier({ module.bulkData.getAnalogInput(port.toInt()).toDouble() })

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/CalcifiedDigitalInput.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/CalcifiedDigitalInput.kt
@@ -6,8 +6,8 @@ import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 import dev.frozenmilk.dairy.core.util.supplier.logical.EnhancedBooleanSupplier
 import dev.frozenmilk.dairy.core.util.supplier.logical.IEnhancedBooleanSupplier
 
-class CalcifiedDigitalInput(val module: CalcifiedModule, val port: Byte) : IEnhancedBooleanSupplier by EnhancedBooleanSupplier({ module.bulkData.getDigitalInput(port.toInt()) }) {
+class CalcifiedDigitalInput(val module: CalcifiedModule, val port: Int) : IEnhancedBooleanSupplier by EnhancedBooleanSupplier({ module.bulkData.getDigitalInput(port) }) {
 	init {
-		LynxSetDIODirectionCommand(module.lynxModule, port.toInt(), DigitalChannel.Mode.INPUT).send()
+		LynxSetDIODirectionCommand(module.lynxModule, port, DigitalChannel.Mode.INPUT).send()
 	}
 }

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/CalcifiedDigitalOutput.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/CalcifiedDigitalOutput.kt
@@ -6,11 +6,11 @@ import com.qualcomm.robotcore.hardware.DigitalChannel
 import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 import java.util.function.Consumer
 
-class CalcifiedDigitalOutput(private val module: CalcifiedModule, private val port: Byte) : Consumer<Boolean> {
+class CalcifiedDigitalOutput(private val module: CalcifiedModule, private val port: Int) : Consumer<Boolean> {
 	init {
-		LynxSetDIODirectionCommand(module.lynxModule, port.toInt(), DigitalChannel.Mode.OUTPUT).send()
+		LynxSetDIODirectionCommand(module.lynxModule, port, DigitalChannel.Mode.OUTPUT).send()
 	}
 	override fun accept(p0: Boolean) {
-		LynxSetSingleDIOOutputCommand(module.lynxModule, port.toInt(), p0).send()
+		LynxSetSingleDIOOutputCommand(module.lynxModule, port, p0).send()
 	}
 }

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/CalcifiedIMU.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/CalcifiedIMU.kt
@@ -3,6 +3,7 @@ package dev.frozenmilk.dairy.calcified.hardware.sensor
 import com.qualcomm.hardware.bosch.BHI260IMU
 import com.qualcomm.hardware.bosch.BNO055IMU
 import com.qualcomm.hardware.bosch.BNO055IMU.Register
+import com.qualcomm.hardware.lynx.LynxI2cDeviceSynch
 import com.qualcomm.hardware.lynx.commands.core.LynxFirmwareVersionManager
 import com.qualcomm.hardware.rev.RevHubOrientationOnRobot
 import com.qualcomm.robotcore.hardware.I2cAddr
@@ -17,7 +18,6 @@ import com.qualcomm.robotcore.hardware.TimestampedData
 import dev.frozenmilk.dairy.calcified.Calcified
 import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 import dev.frozenmilk.dairy.core.Feature
-import dev.frozenmilk.dairy.core.dependencyresolution.dependencies.Dependency
 import dev.frozenmilk.dairy.core.dependencyresolution.dependencyset.DependencySet
 import dev.frozenmilk.dairy.core.util.supplier.numeric.EnhancedUnitSupplier
 import dev.frozenmilk.dairy.core.wrapper.Wrapper
@@ -37,8 +37,9 @@ import org.firstinspires.ftc.robotcore.internal.system.AppUtil
 import java.nio.ByteBuffer
 import java.nio.ByteOrder
 
-class CalcifiedIMU internal constructor(val imuType: LynxModuleImuType, val module: CalcifiedModule, val port: Byte, initialAngles: AngleBasedRobotOrientation) : Feature {
-	val device = LynxFirmwareVersionManager.createLynxI2cDeviceSynch(AppUtil.getDefContext(), module.lynxModule, port.toInt())
+class CalcifiedIMU internal constructor(val imuType: LynxModuleImuType, val module: CalcifiedModule, val port: Int, initialAngles: AngleBasedRobotOrientation) : Feature {
+	val device: LynxI2cDeviceSynch = LynxFirmwareVersionManager.createLynxI2cDeviceSynch(AppUtil.getDefContext(), module.lynxModule, port)
+
 	init {
 		when (imuType) {
 			NONE, UNKNOWN -> throw IllegalStateException("Attempted to access IMU, but no accessible IMU found")

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/DigitalChannels.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/DigitalChannels.kt
@@ -5,14 +5,14 @@ import dev.frozenmilk.dairy.calcified.CalcifiedDeviceMap
 import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 
 class DigitalChannels internal constructor(module: CalcifiedModule) : CalcifiedDeviceMap<Any>(module) {
-	fun getInput(port: Byte): CalcifiedDigitalInput {
+	fun getInput(port: Int): CalcifiedDigitalInput {
 		if (port !in 0 until LynxConstants.NUMBER_OF_DIGITAL_IOS) throw IllegalArgumentException("$port is not in the acceptable port range [0, ${LynxConstants.NUMBER_OF_DIGITAL_IOS - 1}]")
 		if (this.containsKey(port) || this[port] !is CalcifiedDigitalInput) {
 			this[port] = CalcifiedDigitalInput(module, port)
 		}
 		return (this[port] as CalcifiedDigitalInput)
 	}
-	fun getOutput(port: Byte): CalcifiedDigitalOutput {
+	fun getOutput(port: Int): CalcifiedDigitalOutput {
 		if (port !in 0 until LynxConstants.NUMBER_OF_DIGITAL_IOS) throw IllegalArgumentException("$port is not in the acceptable port range [0, ${LynxConstants.NUMBER_OF_DIGITAL_IOS - 1}]")
 		if (this.containsKey(port) || this[port] !is CalcifiedDigitalOutput) {
 			this[port] = CalcifiedDigitalInput(module, port)

--- a/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/I2CDevices.kt
+++ b/src/main/kotlin/dev/frozenmilk/dairy/calcified/hardware/sensor/I2CDevices.kt
@@ -7,7 +7,7 @@ import dev.frozenmilk.dairy.calcified.hardware.CalcifiedModule
 import dev.frozenmilk.util.units.orientation.AngleBasedRobotOrientation
 
 class I2CDevices internal constructor(module: CalcifiedModule) : CalcifiedDeviceMap<Any>(module){
-	fun getIMU(port: Byte, imuType: LynxModuleImuType, angleBasedRobotOrientation: AngleBasedRobotOrientation): CalcifiedIMU {
+	fun getIMU(port: Int, imuType: LynxModuleImuType, angleBasedRobotOrientation: AngleBasedRobotOrientation): CalcifiedIMU {
 		if (port !in 0 until LynxConstants.NUMBER_OF_I2C_BUSSES) throw IllegalArgumentException("$port is not in the acceptable port range [0, ${LynxConstants.NUMBER_OF_I2C_BUSSES - 1}]")
 		if (!this.containsKey(port) || this[port] !is CalcifiedIMU || (this[port] as CalcifiedIMU).imuType != imuType) {
 			this[port] = CalcifiedIMU(imuType, module, port, angleBasedRobotOrientation)
@@ -16,8 +16,8 @@ class I2CDevices internal constructor(module: CalcifiedModule) : CalcifiedDevice
 	}
 
 	@JvmOverloads
-	fun getIMU_BHI260(port: Byte, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()) = this.getIMU(port, LynxModuleImuType.BHI260, angleBasedRobotOrientation)
+	fun getIMU_BHI260(port: Int, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()) = this.getIMU(port, LynxModuleImuType.BHI260, angleBasedRobotOrientation)
 
 	@JvmOverloads
-	fun getIMU_BNO055(port: Byte, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()) = this.getIMU(port, LynxModuleImuType.BNO055, angleBasedRobotOrientation)
+	fun getIMU_BNO055(port: Int, angleBasedRobotOrientation: AngleBasedRobotOrientation = AngleBasedRobotOrientation()) = this.getIMU(port, LynxModuleImuType.BNO055, angleBasedRobotOrientation)
 }


### PR DESCRIPTION
…n order for better Java compatibility (remove the need for casting to byte which was noisy), resolves #4